### PR TITLE
LoadCanvasTemplate: Add a prop for the text

### DIFF
--- a/src/hooks/react-simple-captcha.js
+++ b/src/hooks/react-simple-captcha.js
@@ -3,7 +3,8 @@ import ReactHtmlParser from 'react-html-parser';
 
 let captcha_value = '';
 let captcha_number = '';
-let LoadCanvasTemplate_HTML = "<div><canvas id=\"canv\"></canvas><div><a id=\"reload_href\"  style=\"cursor: pointer; color: blue\">Reload Captcha</a></div></div>";
+let reloadText = "{{reloadText}}";
+let LoadCanvasTemplate_HTML = `<div><canvas id="canv"></canvas><div><a id="reload_href"  style="cursor: pointer; color: blue">${reloadText}</a></div></div>`;
 let LoadCanvasTemplateNoReload_HTML = "<div><canvas id=\"canv\"></canvas><div><a id=\"reload_href\"  style=\"cursor: pointer; color: blue\"></a></div></div>";;
 
 
@@ -78,7 +79,8 @@ export const validateCaptcha = (userValue, reload = true) => {
 export class LoadCanvasTemplate extends Component {
 
     render() {
-        return (ReactHtmlParser(LoadCanvasTemplate_HTML));
+        let text = this.props.reloadText ? this.props.reloadText : "Reload Captcha";
+        return (ReactHtmlParser(LoadCanvasTemplate_HTML.replace(reloadText, text)));
     }
 
 };


### PR DESCRIPTION
Fixes #1

Add a 'reloadText' prop to LoadCanvasTemplate where consumer can pass a
localized text to replace the "Reload Captcha" default text.